### PR TITLE
[ci] use Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test_pull_request:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [12, 14, 15]


### PR DESCRIPTION
This PR fully migrates the Github Actions runner to Ubuntu 20.04